### PR TITLE
Use IteratorObservable in benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ This library is essentially
 
 Method                       | ops/sec
 -----------------------------|-----------------------------------------------:|
-Loop                         | 227 ops/sec ±2.30% (73 runs sampled)
-**iterare**                  | **208 ops/sec ±3.53% (72 runs sampled)**
-Array method chain           | 129 ops/sec ±1.25% (69 runs sampled)
-Lodash (with lazy evalution) | 168 ops/sec ±1.50% (73 runs sampled)
-RxJS                         | 152 ops/sec ±1.93% (76 runs sampled)
+Loop                         | 225 ops/sec ±1.87% (73 runs sampled)
+**iterare**                  | **211 ops/sec ±2.79% (73 runs sampled)**
+Array method chain           | 132 ops/sec ±1.84% (73 runs sampled)
+Lodash (with lazy evalution) | 179 ops/sec ±1.67% (77 runs sampled)
+RxJS                         | 204 ops/sec ±1.69% (75 runs sampled)
 
 ## Contributing
 

--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -3,7 +3,8 @@
 
 import { Event, Suite } from 'benchmark'
 import * as _ from 'lodash'
-import { Observable } from 'rxjs'
+import 'rxjs'
+import { IteratorObservable } from 'rxjs/observable/IteratorObservable.js'
 import { iterate } from './iterate'
 
 const suite = new Suite()
@@ -51,16 +52,16 @@ suite.add('Lodash', () => {
     )
 })
 
-suite.add('RxJS', (deferred: any) => {
-    Observable.from(Array.from(hugeSet))
+suite.add('RxJS', () => {
+    new IteratorObservable<string>(hugeSet[Symbol.iterator]())
         .filter((uri: string) => uri.startsWith('file://'))
         .map(uri => uri.substr('file:///'.length))
         .toArray()
         .map(arr => new Set(arr))
         .subscribe(result => {
-            deferred.resolve()
+            // Finished
         })
-}, { defer: true })
+})
 
 suite.on('cycle', (event: Event) => {
     console.log(String(event.target))


### PR DESCRIPTION
This improves the performance of RxJS in the benchmarks.
Also takes into consideration that RxJS iterates synchronously if the source is synchronous