### PR TITLE
fix: improve toMap typing to allow inferring K and V

### DIFF
--- a/src/iterate.test.ts
+++ b/src/iterate.test.ts
@@ -147,8 +147,9 @@ describe('IteratorWithOperators', () => {
     })
     describe('toSet', () => {
         it('should return all items as a Map', () => {
-            const iterator = new IteratorWithOperators([['foo', 1], ['bar', 2]][Symbol.iterator]())
-            const map = iterator.toMap<string, number>()
+            const arr: [string, number][] = [['foo', 1], ['bar', 2]]
+            const iterator = new IteratorWithOperators(arr[Symbol.iterator]())
+            const map = iterator.toMap()
             assert(map instanceof Map, 'instanceof Map')
             assert.deepEqual(Array.from(map), [['foo', 1], ['bar', 2]])
         })

--- a/src/iterate.ts
+++ b/src/iterate.ts
@@ -246,8 +246,8 @@ export class IteratorWithOperators<T> implements IterableIterator<T> {
      * Iterates and returns all `[key, value]` paris emitted by the Iterator as an ES6 Map.
      * Equivalent to passing the Iterator to `new Map()`
      */
-    toMap<K, V>(): Map<K, V> {
-        return new Map<K, V>(this as any)
+    toMap<K, V>(this: IteratorWithOperators<[K, V]>): Map<K, V> {
+        return new Map<K, V>(this)
     }
 }
 


### PR DESCRIPTION
Alternatively, the signature of `toMap` could be defined as
```ts
toMap<K = T extends [infer X, any] ? X : {}, V = X extends [any, infer X] ? L : {}>(): Map<K, V>
```
and this would allow the test to remain unchanged, but it is less typesafe and requires a typescript 2.8 vs 2.0 for `this`