### PR TITLE
fix: improve typing of flatten to infer return iterator type

### DIFF
--- a/src/iterate.test.ts
+++ b/src/iterate.test.ts
@@ -30,6 +30,18 @@ describe('IteratorWithOperators', () => {
             assert.equal(iterator.next().done, true)
         })
     })
+    describe('flatten', () => {
+        it('should emit values from nested iterables', () => {
+            const collection = [1, [2, [3]], 4, [5]][Symbol.iterator]()
+            const iterator = new IteratorWithOperators(collection).flatten()
+            assert.equal(iterator.next().value, 1)
+            assert.equal(iterator.next().value, 2)
+            assert.deepEqual(iterator.next().value, [3])
+            assert.equal(iterator.next().value, 4)
+            assert.equal(iterator.next().value, 5)
+            assert.equal(iterator.next().done, true)
+        })
+    })
     describe('reduce', () => {
         it('should reduce all emitted values by calling the reducer', () => {
             const iterator = new IteratorWithOperators([1, 2, 4, 3][Symbol.iterator]())

--- a/src/iterate.ts
+++ b/src/iterate.ts
@@ -81,7 +81,7 @@ export class IteratorWithOperators<T> implements IterableIterator<T> {
     /**
      * Returns a new Iterator that flattens items emitted by the Iterator a single level deep
      */
-    flatten<R>(): IteratorWithOperators<R> {
+    flatten<R>(this: IteratorWithOperators<R | Iterator<R> | Iterable<R>>): IteratorWithOperators<R> {
         return new IteratorWithOperators(new FlattenIterator<R>(this.source))
     }
 


### PR DESCRIPTION
Also add a test for flatten, based on flatten.test.ts