### PR TITLE
perf: add obliterator to benchmarks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7534,8 +7534,9 @@
       }
     },
     "obliterator": {
-      "version": "github:forivall/obliterator#1eba70206fb772cec2c9171d82ccb6ede584f904",
-      "from": "github:forivall/obliterator#patch-1",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
       "dev": true
     },
     "octokit-pagination-methods": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7533,6 +7533,11 @@
         }
       }
     },
+    "obliterator": {
+      "version": "github:forivall/obliterator#1eba70206fb772cec2c9171d82ccb6ede584f904",
+      "from": "github:forivall/obliterator#patch-1",
+      "dev": true
+    },
     "octokit-pagination-methods": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "lodash": "^4.17.11",
     "mocha": "^6.1.4",
     "nyc": "^14.1.1",
+    "obliterator": "github:forivall/obliterator#patch-1",
     "prettier": "^1.18.1",
     "rxjs": "^6.5.2",
     "semantic-release": "^15.13.12",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "lodash": "^4.17.11",
     "mocha": "^6.1.4",
     "nyc": "^14.1.1",
-    "obliterator": "github:forivall/obliterator#patch-1",
+    "obliterator": "^1.6.1",
     "prettier": "^1.18.1",
     "rxjs": "^6.5.2",
     "semantic-release": "^15.13.12",

--- a/src/benchmarks/filter_take_set.ts
+++ b/src/benchmarks/filter_take_set.ts
@@ -4,6 +4,7 @@ import * as IxES6 from '@reactivex/ix-es2015-cjs'
 import { Event, Suite } from 'benchmark'
 import * as IxES5 from 'ix'
 import * as _ from 'lodash'
+import * as obl from 'obliterator';
 import 'rxjs'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
@@ -86,6 +87,17 @@ suite.add('IxJS (ES6)', () => {
         .filter((uri: string) => uri.startsWith('file://'))
         .take(5)
         .toSet()
+})
+
+suite.add('obliterator', () => {
+    return new Set(
+        obl.take(
+            obl.filter(
+                (uri: string) => uri.startsWith('file://'),
+                hugeSet[Symbol.iterator]()
+            ), 5
+        )
+    );
 })
 
 suite.on('cycle', (event: Event) => {

--- a/src/benchmarks/map_filter_set.ts
+++ b/src/benchmarks/map_filter_set.ts
@@ -4,6 +4,7 @@ import * as IxES6 from '@reactivex/ix-es2015-cjs'
 import { Event, Suite } from 'benchmark'
 import * as IxES5 from 'ix'
 import * as _ from 'lodash'
+import * as obl from 'obliterator';
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 import { iterate } from '../iterate'
@@ -78,6 +79,18 @@ suite.add('IxJS (ES6)', () => {
         .filter((uri: string) => uri.startsWith('file://'))
         .map(uri => uri.substr('file:///'.length))
         .toSet()
+})
+
+suite.add('obliterator', () => {
+    return new Set(
+        obl.map(
+            uri => uri.substr('file:///'.length),
+            obl.filter(
+                (uri: string) => uri.startsWith('file://'),
+                hugeSet[Symbol.iterator]()
+            ),
+        )
+    );
 })
 
 suite.on('cycle', (event: Event) => {


### PR DESCRIPTION
I was curious about the performance compared to [obliterator](https://github.com/Yomguithereal/obliterator) (using my fork to fix the type definitions), so i added it to the benchmark. You're still the fastest lib.

```
~pubrepos/iterare master*
» node ./lib/benchmarks/filter_take_set.js
Loop x 2,102,039 ops/sec ±1.37% (86 runs sampled)
iterare x 603,265 ops/sec ±2.23% (82 runs sampled)
Array method chain x 43.79 ops/sec ±1.17% (57 runs sampled)
Lodash x 642 ops/sec ±1.19% (85 runs sampled)
RxJS x 110,212 ops/sec ±4.47% (88 runs sampled)
IxJS (ES5) x 359,412 ops/sec ±1.11% (89 runs sampled)
IxJS (ES6) x 325,086 ops/sec ±2.87% (82 runs sampled)
obliterator x 416,279 ops/sec ±1.95% (87 runs sampled)
Fastest is Loop

~pubrepos/iterare master* 49s
» node ./lib/benchmarks/map_filter_set.js
Loop x 408 ops/sec ±1.96% (83 runs sampled)
iterare x 382 ops/sec ±1.06% (83 runs sampled)
Array method chain x 340 ops/sec ±5.81% (84 runs sampled)
Lodash x 363 ops/sec ±1.36% (85 runs sampled)
RxJS x 342 ops/sec ±1.36% (84 runs sampled)
IxJS (ES5) x 201 ops/sec ±2.41% (80 runs sampled)
IxJS (ES6) x 212 ops/sec ±1.09% (81 runs sampled)
obliterator x 258 ops/sec ±1.29% (79 runs sampled)
Fastest is Loop
```