### PR TITLE
fix: join() with arbitrary separators

### DIFF
--- a/src/iterate.test.ts
+++ b/src/iterate.test.ts
@@ -13,6 +13,16 @@ describe('IteratorWithOperators', () => {
             const joined = iterator.join()
             assert.equal(joined, '')
         })
+        it("should join with given separator, ''", () => {
+            const iterator = new IteratorWithOperators([1, 2, 'a', 'b'][Symbol.iterator]())
+            const joined = iterator.join('')
+            assert.equal(joined, '12ab')
+        })
+        it("should join with given separator, 'foo'", () => {
+            const iterator = new IteratorWithOperators([1, 2, 'a', 'b'][Symbol.iterator]())
+            const joined = iterator.join('foo')
+            assert.equal(joined, '1foo2fooafoob')
+        })
     })
     describe('flatten', () => {
         it('should flatten nested Iterables', () => {

--- a/src/iterate.ts
+++ b/src/iterate.ts
@@ -216,7 +216,7 @@ export class IteratorWithOperators<T> implements IterableIterator<T> {
             }
             joined += separator + result.value
         }
-        return joined.substr(1)
+        return joined.substr(separator.length)
     }
 
     /**


### PR DESCRIPTION
Fixes #27 and adds relevant test cases.